### PR TITLE
chore(cloudbuild.yaml): using substitutions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 # the base image: https://github.com/linuxserver/docker-openssh-server
 FROM linuxserver/openssh-server
 
-# these ARG entries match the `--build-arg` from `cloudbuild.yaml`
-ARG CLOUDSDK_VERSION=437.0.1
-ARG CSQL_PROXY_VERSION=2.4.0
-ARG ALLOYDB_PROXY_VERSION=1.3.0
-ARG USQL_VERSION=0.14.8
-ARG SERVICE_PORT=8080
-ARG SSH_USER=test
-ARG SSH_PASS=test
+ARG CLOUDSDK_VERSION
+ARG CSQL_PROXY_VERSION
+ARG ALLOYDB_PROXY_VERSION
+ARG USQL_VERSION
+ARG SERVICE_PORT
+ARG SSH_USER
+ARG SSH_PASS
 
 ENV SUDO_ACCESS=true
 ENV PASSWORD_ACCESS=true
@@ -46,7 +45,7 @@ RUN tar -xvf /usql_static-${USQL_VERSION}-linux-amd64.tar.bz2 \
 
 RUN echo -n "${HTTP_PORT}" > /http.port
 
-EXPOSE ${SERVICE_PORT}/tcp
+EXPOSE ${HTTP_PORT}/tcp
 
 # web ssh terminal: https://github.com/huashengdun/webssh
-CMD ["/bin/bash", "-c", "export HTTP_PORT=$(cat /http.port | tr -d '\n') && exec wssh --port=${HTTP_PORT} --xheaders=False"]
+CMD ["/bin/bash", "-c", "export HTTP_PORT=$(cat /http.port) && exec wssh --port=${HTTP_PORT} --xheaders=False"]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,30 @@
-# cloud-run-ssh
+# Cloud Run SSH image
 
-```shell
-docker build run-ssh-server:latest \
---build-arg="CLOUDSDK_VERSION=..." \
---build-arg="CSQL_PROXY_VERSION=..." \
---build-arg="ALLOYDB_PROXY_VERSION=..." \
---build-arg="USQL_VERSION=..." \
---build-arg="SERVICE_PORT=..." \
---build-arg="USER_NAME=..." \
---build-arg="USER_PASS=..." \
--t  .
+## Building the image
+```sh
+gcloud builds submit --config cloudbuild.yaml
 ```
+
+## Deploying the image
+Replace the following variables below
+- _SERVICE_NAME
+- _PROJECT_ID
+- _REGION
+
+and run the command:
+```sh
+gcloud run deploy $_SERVICE_NAME --image=gcr.io/$_PROJECT_ID/$_SERVICE_NAME \
+--region=$_REGION --port=8080 --min-instances=1 \
+--max-instances=1 --timeout=3600s --no-use-http2 --session-affinity \
+--memory=4Gi --cpu=2 --cpu-boost --no-cpu-throttling --execution-environment=gen2 \
+--allow-unauthenticated
+```
+
+## SSHing into the container
+1. Open the service's URL
+1. Fill in the following fields:
+ - Hostname: `127.0.0.1` (fixed)
+ - Port: `2222` (fixed)
+ - Username: $_USER_NAME # identical to the value in cloudbuild.yaml
+ - Password: $_USER_PASS # identical to the value in cloudbuild.yaml
+1. Click `Connect`

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,23 +1,33 @@
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-    - build
-    # https://cloud.google.com/sdk/docs/release-notes ( i/e: 455.0.0 )
-    - --build-arg
-    - CLOUDSDK_VERSION=455.0.0
-    # https://github.com/GoogleCloudPlatform/cloud-sql-proxy/releases ( i/e: 2.4.0 )
-    - --build-arg
-    - CSQL_PROXY_VERSION=2.4.0
-    # https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/releases ( i/e: 1.3.0 )
-    - --build-arg
-    - ALLOYDB_PROXY_VERSION=1.3.0
+steps:
+  - id: "build image"
+    name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'gcr.io/${_PROJECT_ID}/${_SERVICE_NAME}'
+      - '--build-arg=CLOUDSDK_VERSION=${_CLOUDSDK_VERSION}'
+      - '--build-arg=CSQL_PROXY_VERSION=${_CSQL_PROXY_VERSION}'
+      - '--build-arg=ALLOYDB_PROXY_VERSION=${_ALLOYDB_PROXY_VERSION}'
+      - '--build-arg=USQL_VERSION=${_USQL_VERSION}'
+      - '--build-arg=SERVICE_PORT=${_SERVICE_PORT}'
+      - '--build-arg=SSH_USER=${_USER_NAME}'
+      - '--build-arg=SSH_PASS=${_USER_PASS}'
+      - '.'
+  - id: "push image"
+    name: "gcr.io/cloud-builders/docker"
+    args: ["push", "gcr.io/${_PROJECT_ID}/${_SERVICE_NAME}"]
+
+substitutions:
+  _PROJECT_ID: PROJECT-ID
+  _SERVICE_NAME: SERVICE-NAME
+  # http://cloud/sdk/docs/release-notes ( i/e: 437.0.1 )
+  _CLOUDSDK_VERSION: 459.0.0
+  # https://github.com/GoogleCloudPlatform/cloud-sql-proxy/releases ( i/e: 2.4.0 )
+  _CSQL_PROXY_VERSION: 2.8.1
+   # https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/releases ( i/e: 1.3.0 )
+  _ALLOYDB_PROXY_VERSION: 1.6.1
     # https://github.com/xo/usql/releases ( i/e: 0.14.8 )
-    - --build-arg
-    - USQL_VERSION=0.14.8
-    - --build-arg
-    - USER_NAME=test
-    - --build-arg
-    - USER_PASSWORD=test
-    - --build-arg
-    - SERVICE_PORT=8080
-    - --tag
-    - us-docker.pkg.dev/chux-testing/serverless/ssh
+  _USQL_VERSION: 0.17.5
+  _SERVICE_PORT: '8080' # You can replace this
+  _USER_NAME: 'user' # Choose a username
+  _USER_PASS: '123123' # Choose a password


### PR DESCRIPTION
- moved current variables to `cloudbuild.yaml`
- wrote basic `README.md` instructions on running the commands