### PR TITLE
chore(generate_credentials.sh): automate username+password creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ docker build -t <image-name>:<image-tag> \
 gcloud builds submit --config cloudbuild.yaml \
 --substitutions '_REPO_LOCATION=<repo-location>,_REPO_NAME=<repo-name>,_IMAGE_NAME=<image-name>,_IMAGE_TAG=<image-tag>,_BUILD_TAG=<build-tag>' .
 ```
+## (Optional) Using dynamic credentials
+
+### Generating credentials
+Instead of using the default (weak) provided values for the username and password, we can generate a username with `uuidgen` and a password with `openssl rand`.
+
+```sh
+chmod +x generate_credentials.sh
+./generate_credentials.sh 
+```
+Place the output values in the `cloudbuild.yaml`'s `_USER_NAME` and `_USER_PASS`.
 
 ## Deploying the image to Cloud Run
 
@@ -55,3 +65,6 @@ gcloud run deploy ${SERVICE_NAME} --image=${IMAGE_URI} \
     - Password: `$_USER_PASS` # identical to the value in cloudbuild.yaml
 
 3. Click `Connect`
+
+## References
+- https://www.openssl.org/docs/man1.1.1/man1/rand.html

--- a/generate_credentials.sh
+++ b/generate_credentials.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+USER_NAME=$(uuidgen | tr '-' 'a' | cut -c -8)
+USER_PASS=$(openssl rand -base64 12)
+
+echo "Generated Username: $USER_NAME"
+echo "Generated Password: $USER_PASS"
+
+# Optional: remove if you don't want to write to a file
+echo $USER_NAME > credentials.txt
+echo $USER_PASS >> credentials.txt


### PR DESCRIPTION
## What this PR adds
- `generate_credentials.sh` uses `uuidgen` and `openssl rand` to generate a username and a password
- `README.md` talks about this option

## Ideas for improvement
- use Cloud Secrets Manager to store the `username + password` combination instead of hardcoded strings
- have the values be generated at build time, without the user having to manually run the script