### PR TITLE
[fix] python fails to install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV HTTP_PORT=${SERVICE_PORT}
 
 RUN apk update
 RUN apk add busybox-extras net-tools bind-tools iproute2 curl tmux git \
-    bc traceroute tcptraceroute tcpdump mtr nmap redis python3 py3-pip
+    bc traceroute tcptraceroute tcpdump mtr nmap redis python3-dev py3-pip gcc libc-dev libffi-dev
 RUN wget -P /usr/bin http://www.vdberg.org/~richard/tcpping
 RUN chmod a+rx /usr/bin/tcpping
 RUN python -m pip install --break-system-packages httpie webssh


### PR DESCRIPTION
When python is installing, I get this error:
`error: command '/usr/bin/gcc' failed with exit code 1`

Fixed this by adding a few more packages and switching to python3-dev, per this [StackOverflow advice](https://stackoverflow.com/a/70316507/26382611).